### PR TITLE
Clone all commits to load docs history correctly

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: recursive
+          fetch-depth: 0
       - name: Setup Node
         uses: actions/setup-node@v1
         with:


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d656498f-43c2-4f8c-930e-56e291d3545b)

![image](https://github.com/user-attachments/assets/499467ca-6280-4173-a2a0-bb1695a816c3)

Fetch all the commits to let hugo know file history.

Benefit:
1. Show docs history correctly
2. Minimize the publish commit. The `deploy action` will only modify those files being modified in current PR, not all the files.


![image](https://github.com/user-attachments/assets/4fa616ca-2161-4f34-878d-0e59aa056a78)
